### PR TITLE
Add eSports tracking page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# eSports Tracker
+
+This project aims to provide an application to follow electronic sports competitions with a design inspired by Fotmob. It was bootstrapped with [Next.js](https://nextjs.org) using [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
 ## Getting Started
 

--- a/app/esports/page.tsx
+++ b/app/esports/page.tsx
@@ -1,0 +1,68 @@
+import Image from "next/image";
+
+interface Match {
+  id: number;
+  teams: [string, string];
+  date: string;
+  time: string;
+  tournament: string;
+  score?: [number, number];
+}
+
+const matches: Match[] = [
+  {
+    id: 1,
+    teams: ["Team Liquid", "Fnatic"],
+    date: "2024-08-01",
+    time: "18:00 CET",
+    tournament: "League of Legends Championship",
+    score: [2, 1],
+  },
+  {
+    id: 2,
+    teams: ["NAVI", "G2"],
+    date: "2024-08-03",
+    time: "20:00 CET",
+    tournament: "Counter-Strike Masters",
+  },
+  {
+    id: 3,
+    teams: ["Cloud9", "T1"],
+    date: "2024-08-05",
+    time: "17:00 CET",
+    tournament: "Valorant World Series",
+  },
+];
+
+export default function EsportsPage() {
+  return (
+    <main className="p-4 sm:p-8 font-sans">
+      <h1 className="text-2xl font-bold mb-4">Próximos partidos eSports</h1>
+      <ul className="space-y-4">
+        {matches.map((match) => (
+          <li
+            key={match.id}
+            className="border rounded-lg p-4 flex flex-col sm:flex-row sm:items-center gap-2"
+          >
+            <div className="flex-1">
+              <p className="font-semibold">
+                {match.teams[0]} vs {match.teams[1]}
+              </p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {match.date} • {match.time}
+              </p>
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                {match.tournament}
+              </p>
+            </div>
+            {match.score && (
+              <div className="text-lg font-bold">
+                {match.score[0]}-{match.score[1]}
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,103 +1,19 @@
-import Image from "next/image";
+import Link from "next/link";
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+    <main className="p-4 sm:p-8 font-sans flex flex-col items-center gap-6">
+      <h1 className="text-3xl font-bold">Seguimiento de eSports</h1>
+      <p className="text-center max-w-md">
+        Bienvenido a la aplicación de seguimiento de deportes electrónicos. Consulta
+        los próximos encuentros y resultados de tus equipos favoritos.
+      </p>
+      <Link
+        href="/esports"
+        className="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-4 py-2 rounded"
+      >
+        Ver partidos
+      </Link>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- create `esports` route with sample match data
- simplify the home page and link to the new section
- document project purpose in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6851d6f5a8888332a233a46a22c4aa58