### PR TITLE
Add dynamic Dota match feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project aims to provide an application to follow electronic sports competitions with a design inspired by Fotmob. It was bootstrapped with [Next.js](https://nextjs.org) using [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+The `/esports` section now fetches real match data from the [OpenDota API](https://api.opendota.com), displaying recent professional Dota 2 games.
+
 ## Getting Started
 
 First, run the development server:

--- a/app/esports/page.tsx
+++ b/app/esports/page.tsx
@@ -1,43 +1,43 @@
-import Image from "next/image";
-
 interface Match {
   id: number;
-  teams: [string, string];
-  date: string;
-  time: string;
-  tournament: string;
-  score?: [number, number];
+  radiant: string;
+  dire: string;
+  radiant_score: number;
+  dire_score: number;
+  start_time: number;
+  league: string;
+  radiant_win: boolean;
 }
 
-const matches: Match[] = [
-  {
-    id: 1,
-    teams: ["Team Liquid", "Fnatic"],
-    date: "2024-08-01",
-    time: "18:00 CET",
-    tournament: "League of Legends Championship",
-    score: [2, 1],
-  },
-  {
-    id: 2,
-    teams: ["NAVI", "G2"],
-    date: "2024-08-03",
-    time: "20:00 CET",
-    tournament: "Counter-Strike Masters",
-  },
-  {
-    id: 3,
-    teams: ["Cloud9", "T1"],
-    date: "2024-08-05",
-    time: "17:00 CET",
-    tournament: "Valorant World Series",
-  },
-];
+export const dynamic = "force-dynamic";
 
-export default function EsportsPage() {
+async function getMatches(): Promise<Match[]> {
+  const res = await fetch(
+    "https://api.opendota.com/api/proMatches?less_than_match_id=9999999999"
+  );
+  if (!res.ok) {
+    console.error("Failed to fetch matches", await res.text());
+    return [];
+  }
+  const data = await res.json();
+  return data.slice(0, 10).map((m: any) => ({
+    id: m.match_id,
+    radiant: m.radiant_name,
+    dire: m.dire_name,
+    radiant_score: m.radiant_score,
+    dire_score: m.dire_score,
+    start_time: m.start_time,
+    league: m.league_name,
+    radiant_win: m.radiant_win,
+  }));
+}
+
+export default async function EsportsPage() {
+  const matches = await getMatches();
+
   return (
     <main className="p-4 sm:p-8 font-sans">
-      <h1 className="text-2xl font-bold mb-4">Próximos partidos eSports</h1>
+      <h1 className="text-2xl font-bold mb-4">Partidos profesionales Dota 2</h1>
       <ul className="space-y-4">
         {matches.map((match) => (
           <li
@@ -46,20 +46,19 @@ export default function EsportsPage() {
           >
             <div className="flex-1">
               <p className="font-semibold">
-                {match.teams[0]} vs {match.teams[1]}
+                {match.radiant} vs {match.dire}
               </p>
               <p className="text-sm text-gray-500 dark:text-gray-400">
-                {match.date} • {match.time}
+                {new Date(match.start_time * 1000).toLocaleString()}
               </p>
               <p className="text-sm text-gray-600 dark:text-gray-300">
-                {match.tournament}
+                {match.league}
               </p>
             </div>
-            {match.score && (
-              <div className="text-lg font-bold">
-                {match.score[0]}-{match.score[1]}
-              </div>
-            )}
+            <div className="text-lg font-bold">
+              {match.radiant_score}-{match.dire_score}{" "}
+              {match.radiant_win ? "(Radiant win)" : "(Dire win)"}
+            </div>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- pull recent professional Dota 2 matches from OpenDota
- show the fetched matches in the `/esports` page
- document the new data source in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6851f20f7a4c8332b93351d0930c7d45