### PR TITLE
Update styling with FotMob aesthetic

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+export default function Header() {
+  return (
+    <header className="bg-[#0f0f0f] border-b border-[#2a2a2a] py-4">
+      <div className="container mx-auto flex justify-between px-4">
+        <Link href="/" className="text-xl font-bold text-[var(--accent)]">
+          eSports Tracker
+        </Link>
+        <nav className="flex gap-4 items-center">
+          <Link
+            href="/esports"
+            className="text-sm text-gray-300 hover:text-[var(--accent)]"
+          >
+            Partidos
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/app/esports/page.tsx
+++ b/app/esports/page.tsx
@@ -37,25 +37,25 @@ export default async function EsportsPage() {
 
   return (
     <main className="p-4 sm:p-8 font-sans">
-      <h1 className="text-2xl font-bold mb-4">Partidos profesionales Dota 2</h1>
+      <h1 className="text-2xl font-bold text-[var(--accent)] mb-4">
+        Partidos profesionales Dota 2
+      </h1>
       <ul className="space-y-4">
         {matches.map((match) => (
           <li
             key={match.id}
-            className="border rounded-lg p-4 flex flex-col sm:flex-row sm:items-center gap-2"
+            className="card p-4 flex flex-col sm:flex-row sm:items-center gap-2"
           >
             <div className="flex-1">
               <p className="font-semibold">
                 {match.radiant} vs {match.dire}
               </p>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
+              <p className="text-sm text-gray-400">
                 {new Date(match.start_time * 1000).toLocaleString()}
               </p>
-              <p className="text-sm text-gray-600 dark:text-gray-300">
-                {match.league}
-              </p>
+              <p className="text-sm text-gray-500">{match.league}</p>
             </div>
-            <div className="text-lg font-bold">
+            <div className="text-lg font-bold text-[var(--accent)]">
               {match.radiant_score}-{match.dire_score}{" "}
               {match.radiant_win ? "(Radiant win)" : "(Dire win)"}
             </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,26 +1,38 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #0a0a0a;
+  --foreground: #ededed;
+  --accent: #33b864;
+  --card: #171717;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-accent: var(--accent);
+  --color-card: var(--card);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: light) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #ffffff;
+    --foreground: #171717;
+    --accent: #33b864;
+    --card: #f5f5f5;
   }
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans), Arial, Helvetica, sans-serif;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid #2a2a2a;
+  border-radius: 0.5rem;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Header from "./components/Header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,8 +26,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[var(--background)] text-[var(--foreground)]`}
       >
+        <Header />
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,14 +3,14 @@ import Link from "next/link";
 export default function Home() {
   return (
     <main className="p-4 sm:p-8 font-sans flex flex-col items-center gap-6">
-      <h1 className="text-3xl font-bold">Seguimiento de eSports</h1>
+      <h1 className="text-3xl font-bold text-[var(--accent)]">Seguimiento de eSports</h1>
       <p className="text-center max-w-md">
         Bienvenido a la aplicación de seguimiento de deportes electrónicos. Consulta
         los próximos encuentros y resultados de tus equipos favoritos.
       </p>
       <Link
         href="/esports"
-        className="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-4 py-2 rounded"
+        className="bg-[var(--accent)] hover:bg-green-600 text-white font-semibold px-4 py-2 rounded"
       >
         Ver partidos
       </Link>


### PR DESCRIPTION
## Summary
- add site-wide dark theme colors inspired by FotMob
- create a header component
- update layout and pages with new colors and header

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6851f341da6083328c936282ef4e885f