### PR TITLE
Add match detail page

### DIFF
--- a/app/esports/[matchId]/page.tsx
+++ b/app/esports/[matchId]/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+interface MatchDetail {
+  id: number;
+  name: string;
+  radiant: string;
+  dire: string;
+  radiant_score: number;
+  dire_score: number;
+  start_time: number;
+  league: string;
+  radiant_win: boolean;
+}
+
+const PANDA_SCORE_TOKEN =
+  "_PSqzloyu4BibH0XiUvNHvm9AjjnwqcrIMfwEJou6Y0i4NAXENo";
+
+async function fetchMatch(id: string): Promise<MatchDetail | null> {
+  const res = await fetch(
+    `https://api.pandascore.co/matches/${id}?token=${PANDA_SCORE_TOKEN}`,
+    { cache: "no-store" }
+  );
+  if (!res.ok) {
+    console.error("Failed to fetch match", await res.text());
+    return null;
+  }
+  const m = await res.json();
+  const team1 = m.opponents?.[0]?.opponent;
+  const team2 = m.opponents?.[1]?.opponent;
+  return {
+    id: m.id,
+    name: m.name ?? `${team1?.name ?? "TBD"} vs ${team2?.name ?? "TBD"}`,
+    radiant: team1?.name ?? "TBD",
+    dire: team2?.name ?? "TBD",
+    radiant_score: m.results?.[0]?.score ?? 0,
+    dire_score: m.results?.[1]?.score ?? 0,
+    start_time: new Date(m.begin_at ?? m.scheduled_at).getTime() / 1000,
+    league: m.league?.name ?? "",
+    radiant_win:
+      m.winner?.id !== undefined && team1?.id !== undefined
+        ? m.winner.id === team1.id
+        : false,
+  } as MatchDetail;
+}
+
+export default function MatchPage({
+  params,
+}: {
+  params: { matchId: string };
+}) {
+  const [match, setMatch] = useState<MatchDetail | null>(null);
+  const { matchId } = params;
+
+  useEffect(() => {
+    async function load() {
+      const data = await fetchMatch(matchId);
+      setMatch(data);
+    }
+    load();
+  }, [matchId]);
+
+  if (!match) {
+    return (
+      <main className="p-4 sm:p-8 font-sans">
+        <p>Cargando...</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="p-4 sm:p-8 font-sans space-y-4">
+      <Link href="/esports" className="text-[var(--accent)] hover:underline">
+        ← Volver
+      </Link>
+      <h1 className="text-2xl font-bold">{match.name}</h1>
+      <p className="text-sm text-gray-500">{match.league}</p>
+      <p className="text-sm text-gray-400">
+        {new Date(match.start_time * 1000).toLocaleString()}
+      </p>
+      <div className="card p-4 space-y-2">
+        <div className="flex justify-between">
+          <span>{match.radiant}</span>
+          <span className="font-semibold">{match.radiant_score}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>{match.dire}</span>
+          <span className="font-semibold">{match.dire_score}</span>
+        </div>
+        <p className="text-center font-semibold mt-2">
+          Ganó {match.radiant_win ? match.radiant : match.dire}
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/app/esports/page.tsx
+++ b/app/esports/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 
 interface Match {
   id: number;
@@ -123,23 +124,25 @@ export default function EsportsPage() {
         ) : (
           <ul className="space-y-4">
             {filtered.map((match) => (
-              <li
-                key={match.id}
-                className="card p-4 flex flex-col sm:flex-row sm:items-center gap-2"
-              >
-                <div className="flex-1">
-                  <p className="font-semibold">
-                    {match.radiant} vs {match.dire}
-                  </p>
-                  <p className="text-sm text-gray-400">
-                    {new Date(match.start_time * 1000).toLocaleString()}
-                  </p>
-                  <p className="text-sm text-gray-500">{match.league}</p>
-                </div>
-                <div className="text-lg font-bold text-[var(--accent)]">
-                  {match.radiant_score}-{match.dire_score}{" "}
-                  {match.radiant_win ? "(Radiant win)" : "(Dire win)"}
-                </div>
+              <li key={match.id} className="card p-4">
+                <Link
+                  href={`/esports/${match.id}`}
+                  className="flex flex-col sm:flex-row sm:items-center gap-2 hover:opacity-80"
+                >
+                  <div className="flex-1">
+                    <p className="font-semibold">
+                      {match.radiant} vs {match.dire}
+                    </p>
+                    <p className="text-sm text-gray-400">
+                      {new Date(match.start_time * 1000).toLocaleString()}
+                    </p>
+                    <p className="text-sm text-gray-500">{match.league}</p>
+                  </div>
+                  <div className="text-lg font-bold text-[var(--accent)]">
+                    {match.radiant_score}-{match.dire_score}{" "}
+                    {match.radiant_win ? "(Radiant win)" : "(Dire win)"}
+                  </div>
+                </Link>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- allow clicking on a match to open a detail page
- show match information with scores and winner information

## Testing
- `npm run lint` *(fails: requires ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_b_6852832f547883329c41b5e4a59b950f