### PR TITLE
Fix /esports page build error

### DIFF
--- a/app/esports/[matchId]/page.tsx
+++ b/app/esports/[matchId]/page.tsx
@@ -46,13 +46,13 @@ async function fetchMatch(id: string): Promise<MatchDetail | null> {
   } as MatchDetail;
 }
 
-export default function MatchPage({
+export default async function MatchPage({
   params,
 }: {
-  params: { matchId: string };
+  params: Promise<{ matchId: string }>;
 }) {
+  const { matchId } = await params;
   const [match, setMatch] = useState<MatchDetail | null>(null);
-  const { matchId } = params;
 
   useEffect(() => {
     async function load() {


### PR DESCRIPTION
## Summary
- adjust dynamic route parameters in MatchPage to satisfy Next.js' `PageProps`

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68528776e5008332a999689116521617