### PR TITLE
Fix CORS issues for /esports

### DIFF
--- a/app/api/esports/match/[id]/route.ts
+++ b/app/api/esports/match/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+const PANDA_SCORE_TOKEN = "_PSqzloyu4BibH0XiUvNHvm9AjjnwqcrIMfwEJou6Y0i4NAXENo";
+
+export async function GET(
+  request: Request,
+  context: any
+) {
+  const { id } = context.params;
+  const res = await fetch(
+    `https://api.pandascore.co/matches/${id}?token=${PANDA_SCORE_TOKEN}`,
+    { cache: "no-store" }
+  );
+  if (!res.ok) {
+    return new NextResponse("Failed to fetch match", { status: res.status });
+  }
+  const data = await res.json();
+  return NextResponse.json(data);
+}

--- a/app/api/esports/matches/route.ts
+++ b/app/api/esports/matches/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+
+const PANDA_SCORE_TOKEN = "_PSqzloyu4BibH0XiUvNHvm9AjjnwqcrIMfwEJou6Y0i4NAXENo";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const game = searchParams.get("game") || "dota2";
+  const res = await fetch(
+    `https://api.pandascore.co/${game}/matches?per_page=50&token=${PANDA_SCORE_TOKEN}`,
+    { cache: "no-store" }
+  );
+  if (!res.ok) {
+    return new NextResponse("Failed to fetch matches", { status: res.status });
+  }
+  const data = await res.json();
+  return NextResponse.json(data);
+}

--- a/app/esports/[matchId]/page.tsx
+++ b/app/esports/[matchId]/page.tsx
@@ -15,14 +15,9 @@ interface MatchDetail {
   radiant_win: boolean;
 }
 
-const PANDA_SCORE_TOKEN =
-  "_PSqzloyu4BibH0XiUvNHvm9AjjnwqcrIMfwEJou6Y0i4NAXENo";
 
 async function fetchMatch(id: string): Promise<MatchDetail | null> {
-  const res = await fetch(
-    `https://api.pandascore.co/matches/${id}?token=${PANDA_SCORE_TOKEN}`,
-    { cache: "no-store" }
-  );
+  const res = await fetch(`/api/esports/match/${id}`, { cache: "no-store" });
   if (!res.ok) {
     console.error("Failed to fetch match", await res.text());
     return null;

--- a/app/esports/page.tsx
+++ b/app/esports/page.tsx
@@ -14,8 +14,6 @@ interface Match {
   radiant_win: boolean;
 }
 
-const PANDA_SCORE_TOKEN =
-  "_PSqzloyu4BibH0XiUvNHvm9AjjnwqcrIMfwEJou6Y0i4NAXENo";
 
 const GAMES = [
   { id: "dota2", name: "Dota 2" },
@@ -30,10 +28,9 @@ const DAYS = [
 ];
 
 async function fetchMatches(game: string): Promise<Match[]> {
-  const res = await fetch(
-    `https://api.pandascore.co/${game}/matches?per_page=50&token=${PANDA_SCORE_TOKEN}`,
-    { cache: "no-store" }
-  );
+  const res = await fetch(`/api/esports/matches?game=${game}`, {
+    cache: "no-store",
+  });
   if (!res.ok) {
     console.error("Failed to fetch matches", await res.text());
     return [];


### PR DESCRIPTION
## Summary
- proxy PandaScore API through new Next.js route handlers
- update esports pages to call internal API endpoints

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6852891484148332a883d2961a861669