### PR TITLE
Add proxy agent for API routes

### DIFF
--- a/app/api/esports/match/[id]/route.ts
+++ b/app/api/esports/match/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { getProxyAgent } from "../../../../lib/proxyAgent";
 
 const PANDA_SCORE_TOKEN = "_PSqzloyu4BibH0XiUvNHvm9AjjnwqcrIMfwEJou6Y0i4NAXENo";
 
@@ -9,7 +10,7 @@ export async function GET(
   const { id } = context.params;
   const res = await fetch(
     `https://api.pandascore.co/matches/${id}?token=${PANDA_SCORE_TOKEN}`,
-    { cache: "no-store" }
+    { cache: "no-store", agent: getProxyAgent() }
   );
   if (!res.ok) {
     return new NextResponse("Failed to fetch match", { status: res.status });

--- a/app/api/esports/matches/route.ts
+++ b/app/api/esports/matches/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { getProxyAgent } from "../../../lib/proxyAgent";
 
 const PANDA_SCORE_TOKEN = "_PSqzloyu4BibH0XiUvNHvm9AjjnwqcrIMfwEJou6Y0i4NAXENo";
 
@@ -7,7 +8,7 @@ export async function GET(req: Request) {
   const game = searchParams.get("game") || "dota2";
   const res = await fetch(
     `https://api.pandascore.co/${game}/matches?per_page=50&token=${PANDA_SCORE_TOKEN}`,
-    { cache: "no-store" }
+    { cache: "no-store", agent: getProxyAgent() }
   );
   if (!res.ok) {
     return new NextResponse("Failed to fetch matches", { status: res.status });

--- a/app/lib/proxyAgent.ts
+++ b/app/lib/proxyAgent.ts
@@ -1,0 +1,11 @@
+import { HttpsProxyAgent } from "https-proxy-agent";
+import type { Agent } from "https";
+
+export function getProxyAgent(): Agent | undefined {
+  const proxyUrl =
+    process.env.https_proxy ||
+    process.env.HTTPS_PROXY ||
+    process.env.http_proxy ||
+    process.env.HTTP_PROXY;
+  return proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mi-app",
       "version": "0.1.0",
       "dependencies": {
+        "https-proxy-agent": "^7.0.6",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -2404,6 +2405,15 @@
         "win32"
       ]
     },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2969,7 +2979,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3405,6 +3414,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -4735,7 +4757,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "https-proxy-agent": "^7.0.6",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"


### PR DESCRIPTION
## Summary
- add `https-proxy-agent` dependency
- create `getProxyAgent` helper
- use proxy agent in esports API routes

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_68529547437883328fc90c427dfb881a