### PR TITLE
Fix proxy agent import for server runtime

### DIFF
--- a/app/api/esports/match/[id]/route.ts
+++ b/app/api/esports/match/[id]/route.ts
@@ -10,7 +10,9 @@ export async function GET(
   const { id } = context.params;
   const res = await fetch(
     `https://api.pandascore.co/matches/${id}?token=${PANDA_SCORE_TOKEN}`,
-    { cache: "no-store", agent: getProxyAgent() }
+    // Cast to allow the non-standard `agent` option which is used only in
+    // the Node.js runtime.
+    { cache: "no-store", agent: getProxyAgent() } as RequestInit & { agent?: any }
   );
   if (!res.ok) {
     return new NextResponse("Failed to fetch match", { status: res.status });

--- a/app/api/esports/matches/route.ts
+++ b/app/api/esports/matches/route.ts
@@ -8,7 +8,8 @@ export async function GET(req: Request) {
   const game = searchParams.get("game") || "dota2";
   const res = await fetch(
     `https://api.pandascore.co/${game}/matches?per_page=50&token=${PANDA_SCORE_TOKEN}`,
-    { cache: "no-store", agent: getProxyAgent() }
+    // Allow the custom `agent` option in Node.js fetch.
+    { cache: "no-store", agent: getProxyAgent() } as RequestInit & { agent?: any }
   );
   if (!res.ok) {
     return new NextResponse("Failed to fetch matches", { status: res.status });

--- a/app/lib/proxyAgent.ts
+++ b/app/lib/proxyAgent.ts
@@ -1,5 +1,8 @@
-import { HttpsProxyAgent } from "https-proxy-agent";
 import type { Agent } from "https";
+
+// Lazily require "https-proxy-agent" so that it is only loaded in a Node
+// environment. This prevents bundlers from trying to include it in the
+// browser bundle where the module is not available.
 
 export function getProxyAgent(): Agent | undefined {
   const proxyUrl =
@@ -7,5 +10,10 @@ export function getProxyAgent(): Agent | undefined {
     process.env.HTTPS_PROXY ||
     process.env.http_proxy ||
     process.env.HTTP_PROXY;
-  return proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined;
+  if (!proxyUrl) {
+    return undefined;
+  }
+  // Dynamically import the agent implementation only when needed.
+  const { HttpsProxyAgent } = require("https-proxy-agent");
+  return new HttpsProxyAgent(proxyUrl);
 }


### PR DESCRIPTION
## Summary
- lazily require `https-proxy-agent` so the module only loads in Node
- allow custom `agent` option in API routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6852986edf80833288797ebf4180ccfe