### PR TITLE
Add basic Expo project

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,15 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Mobile App with Expo
+
+A simple Expo project is available under the `mobile` directory. You can run it with:
+
+```bash
+cd mobile
+npm install
+npm start
+```
+
+This starts the Expo development server and lets you launch the app on Android, iOS or the web.

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,21 @@
+import { StatusBar } from 'expo-status-bar';
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text>Open up App.tsx to start working on your mobile app!</Text>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,9 @@
+{
+  "expo": {
+    "name": "ESports Tracker Mobile",
+    "slug": "esports-tracker-mobile",
+    "version": "1.0.0",
+    "sdkVersion": "53.0.0",
+    "platforms": ["ios", "android", "web"]
+  }
+}

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo']
+  };
+};

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "esports-tracker-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^53.0.0",
+    "expo-status-bar": "~1.6.0",
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
+    "react-native": "0.74.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0"
+  }
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-native"
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}


### PR DESCRIPTION
## Summary
- add Expo-based mobile project under `mobile`
- document how to run the Expo app

## Testing
- `npm test`
- `npm run lint` *(fails: interactive prompt)*
- `npm run build` *(fails: type error)*

------
https://chatgpt.com/codex/tasks/task_b_6852988a70f08332925da4013b1b6bc5