### PR TITLE
Fix match display for future games

### DIFF
--- a/app/components/Countdown.tsx
+++ b/app/components/Countdown.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export default function Countdown({ targetTime }: { targetTime: number }) {
+  const calc = () => Math.floor(targetTime - Date.now() / 1000);
+  const [remaining, setRemaining] = useState(calc());
+
+  useEffect(() => {
+    const id = setInterval(() => setRemaining(calc()), 1000);
+    return () => clearInterval(id);
+  }, [targetTime]);
+
+  if (remaining <= 0) {
+    return <span>En vivo</span>;
+  }
+  const days = Math.floor(remaining / 86400);
+  const hours = Math.floor((remaining % 86400) / 3600);
+  const minutes = Math.floor((remaining % 3600) / 60);
+  const seconds = remaining % 60;
+  return (
+    <span>
+      Comienza en {days > 0 ? `${days}d ` : ""}
+      {hours.toString().padStart(2, "0")}:
+      {minutes.toString().padStart(2, "0")}:
+      {seconds.toString().padStart(2, "0")}
+    </span>
+  );
+}

--- a/app/esports/[matchId]/page.tsx
+++ b/app/esports/[matchId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, use } from "react";
 import Link from "next/link";
+import Countdown from "../../components/Countdown";
 
 interface MatchDetail {
   id: number;
@@ -12,7 +13,7 @@ interface MatchDetail {
   dire_score: number;
   start_time: number;
   league: string;
-  radiant_win: boolean;
+  radiant_win: boolean | null;
 }
 
 
@@ -37,7 +38,7 @@ async function fetchMatch(id: string): Promise<MatchDetail | null> {
     radiant_win:
       m.winner?.id !== undefined && team1?.id !== undefined
         ? m.winner.id === team1.id
-        : false,
+        : null,
   } as MatchDetail;
 }
 
@@ -75,6 +76,9 @@ export default function MatchPage({
       <p className="text-sm text-gray-400">
         {new Date(match.start_time * 1000).toLocaleString()}
       </p>
+      {match.start_time > Date.now() / 1000 && (
+        <Countdown targetTime={match.start_time} />
+      )}
       <div className="card p-4 space-y-2">
         <div className="flex justify-between">
           <span>{match.radiant}</span>
@@ -85,7 +89,9 @@ export default function MatchPage({
           <span className="font-semibold">{match.dire_score}</span>
         </div>
         <p className="text-center font-semibold mt-2">
-          Ganó {match.radiant_win ? match.radiant : match.dire}
+          {match.radiant_win === null
+            ? "Partido aún no jugado"
+            : `Ganó ${match.radiant_win ? match.radiant : match.dire}`}
         </p>
       </div>
     </main>

--- a/app/esports/page.tsx
+++ b/app/esports/page.tsx
@@ -11,7 +11,7 @@ interface Match {
   dire_score: number;
   start_time: number;
   league: string;
-  radiant_win: boolean;
+  radiant_win: boolean | null;
 }
 
 
@@ -50,7 +50,7 @@ async function fetchMatches(game: string): Promise<Match[]> {
       radiant_win:
         m.winner?.id !== undefined && team1?.id !== undefined
           ? m.winner.id === team1.id
-          : false,
+          : null,
     } as Match;
   });
 }
@@ -137,7 +137,11 @@ export default function EsportsPage() {
                   </div>
                   <div className="text-lg font-bold text-[var(--accent)]">
                     {match.radiant_score}-{match.dire_score}{" "}
-                    {match.radiant_win ? "(Radiant win)" : "(Dire win)"}
+                    {match.radiant_win === null
+                      ? "(Por jugar)"
+                      : match.radiant_win
+                      ? "(Radiant win)"
+                      : "(Dire win)"}
                   </div>
                 </Link>
               </li>


### PR DESCRIPTION
## Summary
- show `(Por jugar)` for matches without results
- add a `Countdown` component
- show a countdown and better winner text on match detail page

## Testing
- `npm test`
- `npm run lint` *(fails: asks for configuration)*

------
https://chatgpt.com/codex/tasks/task_b_6852a5b2a4e883328b7ca2819ec70648