### PR TITLE
Fix dark theme icon visibility

### DIFF
--- a/app/esports/page.tsx
+++ b/app/esports/page.tsx
@@ -98,7 +98,7 @@ export default function EsportsPage() {
                 }`}
               >
                 <span className="flex items-center gap-3 text-lg">
-                  <img src={g.icon} alt="" className="w-6 h-6" />
+                  <img src={g.icon} alt="" className="w-6 h-6 invert" />
                   {g.name}
                 </span>
               </button>


### PR DESCRIPTION
## Summary
- invert game icons so they show up on dark background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6852b1d45df0833293f45e7cee904a86