### PR TITLE
Fix API proxy handling

### DIFF
--- a/app/api/esports/match/[id]/route.ts
+++ b/app/api/esports/match/[id]/route.ts
@@ -5,14 +5,15 @@ const PANDA_SCORE_TOKEN = "_PSqzloyu4BibH0XiUvNHvm9AjjnwqcrIMfwEJou6Y0i4NAXENo";
 
 export async function GET(
   request: Request,
-  context: any
+  { params }: { params: Promise<{ id: string }> }
 ) {
-  const { id } = context.params;
+  const { id } = await params;
   const res = await fetch(
     `https://api.pandascore.co/matches/${id}?token=${PANDA_SCORE_TOKEN}`,
-    // Cast to allow the non-standard `agent` option which is used only in
-    // the Node.js runtime.
-    { cache: "no-store", agent: getProxyAgent() } as RequestInit & { agent?: any }
+    // Use a proxy when running in environments that require it.
+    { cache: "no-store", dispatcher: getProxyAgent() } as RequestInit & {
+      dispatcher?: any;
+    }
   );
   if (!res.ok) {
     return new NextResponse("Failed to fetch match", { status: res.status });

--- a/app/api/esports/matches/route.ts
+++ b/app/api/esports/matches/route.ts
@@ -8,8 +8,10 @@ export async function GET(req: Request) {
   const game = searchParams.get("game") || "dota2";
   const res = await fetch(
     `https://api.pandascore.co/${game}/matches?per_page=50&token=${PANDA_SCORE_TOKEN}`,
-    // Allow the custom `agent` option in Node.js fetch.
-    { cache: "no-store", agent: getProxyAgent() } as RequestInit & { agent?: any }
+    // Use a proxy when running in environments that require it.
+    { cache: "no-store", dispatcher: getProxyAgent() } as RequestInit & {
+      dispatcher?: any;
+    }
   );
   if (!res.ok) {
     return new NextResponse("Failed to fetch matches", { status: res.status });

--- a/app/lib/proxyAgent.ts
+++ b/app/lib/proxyAgent.ts
@@ -1,11 +1,10 @@
-import type { Agent } from "https";
+import type { Dispatcher } from "undici";
 import { createRequire } from "node:module";
 
-// Lazily require "https-proxy-agent" so that it is only loaded in a Node
-// environment. This prevents bundlers from trying to include it in the
-// browser bundle where the module is not available.
+// Lazily import the proxy implementation only when running in Node.js to avoid
+// bundling it for the browser.
 
-export function getProxyAgent(): Agent | undefined {
+export function getProxyAgent(): Dispatcher | undefined {
   const proxyUrl =
     process.env.https_proxy ||
     process.env.HTTPS_PROXY ||
@@ -16,6 +15,6 @@ export function getProxyAgent(): Agent | undefined {
   }
   // Dynamically import the agent implementation only when needed.
   const require = createRequire(import.meta.url);
-  const { HttpsProxyAgent } = require("https-proxy-agent") as typeof import("https-proxy-agent");
-  return new HttpsProxyAgent(proxyUrl);
+  const { ProxyAgent } = require("undici") as typeof import("undici");
+  return new ProxyAgent(proxyUrl);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "https-proxy-agent": "^7.0.6",
         "next": "15.3.3",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "undici": "^7.10.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -5881,6 +5882,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.10.0.tgz",
+      "integrity": "sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "https-proxy-agent": "^7.0.6",
     "next": "15.3.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "undici": "^7.10.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
- support Node `fetch` with proxies via undici `ProxyAgent`
- adjust API routes to use `dispatcher` instead of `agent`
- handle async route params for `/api/esports/match/[id]`
- add `undici` dependency

## Testing
- `npm test`
- `curl -I http://localhost:3000/api/esports/match/1`

------
https://chatgpt.com/codex/tasks/task_b_6852b4b5798c83329ff05dc1e207add2