### PR TITLE
Fix hydration mismatches

### DIFF
--- a/app/components/Countdown.tsx
+++ b/app/components/Countdown.tsx
@@ -3,12 +3,18 @@ import { useEffect, useState } from "react";
 
 export default function Countdown({ targetTime }: { targetTime: number }) {
   const calc = () => Math.floor(targetTime - Date.now() / 1000);
-  const [remaining, setRemaining] = useState(calc());
+  const [remaining, setRemaining] = useState<number | null>(null);
 
   useEffect(() => {
+    // Initialize on mount to avoid mismatches between server and client time
+    setRemaining(calc());
     const id = setInterval(() => setRemaining(calc()), 1000);
     return () => clearInterval(id);
   }, [targetTime]);
+
+  if (remaining === null) {
+    return null;
+  }
 
   if (remaining <= 0) {
     return <span>En vivo</span>;

--- a/app/esports/[matchId]/page.tsx
+++ b/app/esports/[matchId]/page.tsx
@@ -118,7 +118,7 @@ export default function MatchPage({
       <h1 className="text-2xl font-bold">{match.name}</h1>
       <p className="text-sm text-gray-500">{match.league}</p>
       <p className="text-sm text-gray-400">
-        {new Date(match.start_time * 1000).toLocaleString()}
+        {new Date(match.start_time * 1000).toLocaleString("es-ES")}
       </p>
       {match.start_time > Date.now() / 1000 && (
         <Countdown targetTime={match.start_time} />
@@ -151,7 +151,7 @@ export default function MatchPage({
           </li>
           {match.end_time && (
             <li>
-              Finalizado: {new Date(match.end_time * 1000).toLocaleString()}
+              Finalizado: {new Date(match.end_time * 1000).toLocaleString("es-ES")}
             </li>
           )}
         </ul>
@@ -163,7 +163,7 @@ export default function MatchPage({
             {match.games.map((g) => (
               <li key={g.id} className="flex justify-between border-b border-gray-700 py-1">
                 <span>
-                  Juego {g.position}: {g.begin_at ? new Date(g.begin_at).toLocaleString() : ""}
+                  Juego {g.position}: {g.begin_at ? new Date(g.begin_at).toLocaleString("es-ES") : ""}
                 </span>
                 <span>
                   {g.status === "finished" && g.winner_id

--- a/app/esports/page.tsx
+++ b/app/esports/page.tsx
@@ -135,7 +135,7 @@ export default function EsportsPage() {
                       {match.radiant} vs {match.dire}
                     </p>
                     <p className="text-sm text-gray-400">
-                      {new Date(match.start_time * 1000).toLocaleString()}
+                      {new Date(match.start_time * 1000).toLocaleString("es-ES")}
                     </p>
                     <p className="text-sm text-gray-500">{match.league}</p>
                   </div>


### PR DESCRIPTION
## Summary
- avoid Date.now on server in `Countdown` to prevent mismatched markup
- make date formatting stable across server and client by specifying locale

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build` *(fails: cannot find module 'expo-status-bar')*

------
https://chatgpt.com/codex/tasks/task_b_6852b752886c8332abb3b92a27089a22