### PR TITLE
Search recorded Twitch VODs using Gemini

### DIFF
--- a/app/api/esports/vod/route.ts
+++ b/app/api/esports/vod/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { getProxyAgent } from "../../../lib/proxyAgent";
+
+const GEMINI_API_KEY = "AIzaSyDegDWFj78Gl2zrk1CiKO_dJtRNbB2sdGs";
+const GEMINI_MODEL = "models/gemini-1.5-flash-latest";
+
+export async function POST(req: Request) {
+  const { matchName, channel, startTime } = await req.json();
+  if (!matchName || !channel) {
+    return new NextResponse("Missing matchName or channel", { status: 400 });
+  }
+
+  const date = new Date(startTime * 1000).toLocaleDateString("en-US");
+  const prompt = `Find the replay video link on Twitch or elsewhere for the esports match "${matchName}" from channel "${channel}" that took place around ${date}. Respond with only the direct URL if available, otherwise say "Not found".`;
+
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/${GEMINI_MODEL}:generateContent?key=${GEMINI_API_KEY}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] }),
+      dispatcher: getProxyAgent(),
+    } as RequestInit & { dispatcher?: any }
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    return new NextResponse(text || "Failed", { status: res.status });
+  }
+
+  const data = await res.json();
+  const text: string = data.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
+  const match = text.match(/https?:\/\/\S+/);
+  const url = match ? match[0] : null;
+
+  return NextResponse.json({ url, raw: text });
+}

--- a/app/esports/[matchId]/page.tsx
+++ b/app/esports/[matchId]/page.tsx
@@ -93,6 +93,9 @@ export default function MatchPage({
 }) {
   const { matchId } = use(params);
   const [match, setMatch] = useState<MatchDetail | null>(null);
+  const [vodUrl, setVodUrl] = useState<string | null>(null);
+  const [findingVod, setFindingVod] = useState<boolean>(false);
+  const [searchedVod, setSearchedVod] = useState<boolean>(false);
 
   useEffect(() => {
     async function load() {
@@ -101,6 +104,47 @@ export default function MatchPage({
     }
     load();
   }, [matchId]);
+
+  useEffect(() => {
+    if (!match) return;
+    const now = Date.now() / 1000;
+    const ended = match.end_time !== null && now > match.end_time;
+    if (!ended || vodUrl || findingVod || searchedVod) return;
+    const twitch =
+      match.streams.find(
+        (s) => s.embed_url.includes("twitch") || s.raw_url.includes("twitch")
+      ) || match.streams[0];
+    if (!twitch) return;
+    let channel = "";
+    try {
+      const u = new URL(twitch.raw_url || twitch.embed_url);
+      channel = u.pathname.replace(/^\//, "").split("/")[0];
+    } catch {
+      return;
+    }
+    async function searchVod() {
+      setFindingVod(true);
+      setSearchedVod(true);
+      try {
+        const res = await fetch("/api/esports/vod", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            matchName: match.name,
+            channel,
+            startTime: match.start_time,
+          }),
+        });
+        const data = await res.json();
+        if (data.url) setVodUrl(data.url);
+      } catch {
+        /* ignore */
+      } finally {
+        setFindingVod(false);
+      }
+    }
+    searchVod();
+  }, [match, vodUrl, findingVod, searchedVod]);
 
   if (!match) {
     return (
@@ -204,6 +248,20 @@ export default function MatchPage({
               ) || match.streams[0];
             if (!twitch) return null;
             const embedUrl = (() => {
+              if (vodUrl) {
+                const m = vodUrl.match(/videos\/(\d+)/);
+                if (m) {
+                  const url = new URL("https://player.twitch.tv/");
+                  url.searchParams.set("video", m[1]);
+                  if (typeof window !== "undefined") {
+                    if (!url.searchParams.get("parent")) {
+                      url.searchParams.set("parent", window.location.hostname);
+                    }
+                  }
+                  return url.toString();
+                }
+                return vodUrl;
+              }
               try {
                 const url = new URL(twitch.embed_url);
                 if (typeof window !== "undefined") {
@@ -227,6 +285,24 @@ export default function MatchPage({
               </div>
             );
           })()}
+          {findingVod && (
+            <p className="text-sm text-gray-400">Buscando grabación...</p>
+          )}
+          {searchedVod && !vodUrl && !findingVod && (
+            <p className="text-sm text-gray-400">No se encontró grabación</p>
+          )}
+          {vodUrl && (
+            <p className="text-sm">
+              <a
+                href={vodUrl}
+                target="_blank"
+                rel="noopener"
+                className="text-[var(--accent)] hover:underline"
+              >
+                Ver VOD
+              </a>
+            </p>
+          )}
           <ul className="space-y-1 text-sm">
             {match.streams.map((s, idx) => (
               <li key={idx}>


### PR DESCRIPTION
## Summary
- add `/api/esports/vod` endpoint that queries Gemini Flash to locate the recorded match link
- automatically request a VOD for finished matches and embed it if found
- avoid repeatedly searching when no VOD is found
- show a message if no recording is located

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_6852df383a508332bcce4cc0d02fff51