### PR TITLE
Actualizar mensajes cuando el partido está en directo

### DIFF
--- a/app/esports/[matchId]/page.tsx
+++ b/app/esports/[matchId]/page.tsx
@@ -177,9 +177,27 @@ export default function MatchPage({
           <span className="font-semibold">{match.dire_score}</span>
         </div>
         <p className="text-center font-semibold mt-2">
-          {match.radiant_win === null
-            ? "Partido aún no jugado"
-            : `Ganó ${match.radiant_win ? match.radiant : match.dire}`}
+          {(() => {
+            const now = Date.now() / 1000;
+            const started = match.start_time <= now;
+            const live = started && match.radiant_win === null;
+            if (live) {
+              const running = match.games.find((g) => g.status === "running");
+              let minutes = 0;
+              if (running) {
+                const begin = running.begin_at
+                  ? new Date(running.begin_at).getTime()
+                  : match.start_time * 1000;
+                minutes = Math.floor((Date.now() - begin) / 60000);
+                return `Partido en directo - Juego ${running.position} (${minutes}m)`;
+              }
+              minutes = Math.floor((Date.now() - match.start_time * 1000) / 60000);
+              return `Partido en directo (${minutes}m)`;
+            }
+            return match.radiant_win === null
+              ? "Partido aún no jugado"
+              : `Ganó ${match.radiant_win ? match.radiant : match.dire}`;
+          })()}
         </p>
       </div>
       <section className="space-y-2">

--- a/app/esports/page.tsx
+++ b/app/esports/page.tsx
@@ -142,11 +142,17 @@ export default function EsportsPage() {
                   </div>
                   <div className="text-lg font-bold text-[var(--accent)]">
                     {match.radiant_score}-{match.dire_score}{" "}
-                    {match.radiant_win === null
-                      ? "(Por jugar)"
-                      : match.radiant_win
-                      ? "(Radiant win)"
-                      : "(Dire win)"}
+                    {(() => {
+                      const now = Date.now() / 1000;
+                      const started = match.start_time <= now;
+                      const ended = match.radiant_win !== null;
+                      if (started && !ended) return "(En directo)";
+                      return match.radiant_win === null
+                        ? "(Por jugar)"
+                        : match.radiant_win
+                        ? "(Radiant win)"
+                        : "(Dire win)";
+                    })()}
                   </div>
                 </Link>
               </li>


### PR DESCRIPTION
## Summary
- actualizar la lista de partidos para indicar cuando uno está en directo
- mostrar en la página de detalles si el partido está en directo y minutos transcurridos

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_685c14e792c883329e7ca103290d994d