### PR TITLE
Improve tournaments view and add details page

### DIFF
--- a/app/api/esports/tournament/[id]/route.ts
+++ b/app/api/esports/tournament/[id]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { getProxyAgent } from "../../../../lib/proxyAgent";
+
+const PANDA_SCORE_TOKEN = "_PSqzloyu4BibH0XiUvNHvm9AjjnwqcrIMfwEJou6Y0i4NAXENo";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const res = await fetch(
+    `https://api.pandascore.co/tournaments/${id}?token=${PANDA_SCORE_TOKEN}`,
+    { cache: "no-store", dispatcher: getProxyAgent() } as RequestInit & {
+      dispatcher?: any;
+    }
+  );
+  if (!res.ok) {
+    return new NextResponse("Failed to fetch tournament", { status: res.status });
+  }
+  const data = await res.json();
+  return NextResponse.json(data);
+}

--- a/app/esports/page.tsx
+++ b/app/esports/page.tsx
@@ -124,7 +124,11 @@ export default function EsportsPage() {
         return !ended && (started || t.begin_at - now < 60 * 60 * 24 * 45);
       });
       upcomingOrLive.sort((a, b) => (a.begin_at ?? 0) - (b.begin_at ?? 0));
-      setTournaments(upcomingOrLive);
+      const important = upcomingOrLive.filter((t) =>
+        ["s", "a"].includes((t.tier ?? "").toLowerCase())
+      );
+      const list = important.length > 0 ? important : upcomingOrLive;
+      setTournaments(list.slice(0, 5));
       setLoadingTournaments(false);
     }
     load();
@@ -227,10 +231,14 @@ export default function EsportsPage() {
             <ul className="space-y-3">
               {tournaments.map((t) => (
                 <li key={t.id} className="card p-3">
-                  <div className="flex flex-col">
-                    <span className="font-semibold">{t.name}</span>
-                    <span className="text-sm text-gray-400">{t.league}</span>
-                    <span className="text-sm text-gray-500">{t.serie}</span>
+                  <Link
+                    href={`/esports/tournament/${t.id}`}
+                    className="flex flex-col hover:opacity-80"
+                  >
+                    <span className="font-semibold">
+                      {t.league} {t.serie}
+                    </span>
+                    <span className="text-sm text-gray-400">{t.name}</span>
                     {t.begin_at !== null && (
                       <span className="text-sm text-gray-400">
                         {(() => {
@@ -247,7 +255,7 @@ export default function EsportsPage() {
                     {t.prizepool && (
                       <span className="text-sm text-gray-500">{t.prizepool}</span>
                     )}
-                  </div>
+                  </Link>
                 </li>
               ))}
             </ul>

--- a/app/esports/tournament/[id]/page.tsx
+++ b/app/esports/tournament/[id]/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useState, use } from "react";
+import Link from "next/link";
+
+interface TournamentDetail {
+  id: number;
+  name: string;
+  league: string;
+  serie: string;
+  begin_at: string | null;
+  end_at: string | null;
+  prizepool: string | null;
+  tier: string | null;
+  region: string | null;
+  live_supported: boolean;
+}
+
+async function fetchTournament(id: string): Promise<TournamentDetail | null> {
+  const res = await fetch(`/api/esports/tournament/${id}`, { cache: "no-store" });
+  if (!res.ok) return null;
+  const t = await res.json();
+  return {
+    id: t.id,
+    name: t.name ?? "",
+    league: t.league?.name ?? "",
+    serie: t.serie?.full_name ?? "",
+    begin_at: t.begin_at,
+    end_at: t.end_at,
+    prizepool: t.prizepool ?? null,
+    tier: t.tier ?? null,
+    region: t.region ?? null,
+    live_supported: !!t.live_supported,
+  };
+}
+
+export default function TournamentPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const [tournament, setTournament] = useState<TournamentDetail | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      const data = await fetchTournament(id);
+      setTournament(data);
+    }
+    load();
+  }, [id]);
+
+  if (!tournament) {
+    return (
+      <main className="p-4 sm:p-8 font-sans">
+        <p>Cargando...</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="p-4 sm:p-8 font-sans space-y-4">
+      <Link href="/esports" className="text-[var(--accent)] hover:underline">
+        ← Volver
+      </Link>
+      <h1 className="text-2xl font-bold">
+        {tournament.league} {tournament.serie}
+      </h1>
+      <p className="text-sm text-gray-400">{tournament.name}</p>
+      {tournament.begin_at && (
+        <p className="text-sm text-gray-400">
+          Desde {new Date(tournament.begin_at).toLocaleString("es-ES")} {tournament.end_at ? `hasta ${new Date(tournament.end_at).toLocaleString("es-ES")}` : ""}
+        </p>
+      )}
+      {tournament.prizepool && <p className="text-sm">Premio: {tournament.prizepool}</p>}
+      {tournament.region && <p className="text-sm">Región: {tournament.region}</p>}
+      {tournament.tier && <p className="text-sm">Nivel: {tournament.tier.toUpperCase()}</p>}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- show important upcoming tournaments only
- link each tournament to a new details page
- fetch tournament info via new API route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685c2d0eab6883328c5e829153fce69c