### PR TITLE
Fix Vercel build by excluding Expo folder from TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "mobile"]
 }


### PR DESCRIPTION
## Summary
- avoid compiling the Expo project when building Next.js on Vercel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685c39b5ce5c8332a02c879082ad5202