### PR TITLE
Add team search and pages

### DIFF
--- a/app/api/esports/team/[id]/route.ts
+++ b/app/api/esports/team/[id]/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { getProxyAgent } from "../../../../lib/proxyAgent";
+
+const PANDA_SCORE_TOKEN = "_PSqzloyu4BibH0XiUvNHvm9AjjnwqcrIMfwEJou6Y0i4NAXENo";
+
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const url = `https://api.pandascore.co/teams/${id}?token=${PANDA_SCORE_TOKEN}`;
+  const res = await fetch(url, { cache: "no-store", dispatcher: getProxyAgent() } as RequestInit & { dispatcher?: any });
+  if (!res.ok) {
+    return new NextResponse("Failed to fetch team", { status: res.status });
+  }
+  const t = await res.json();
+  const data = {
+    id: t.id,
+    name: t.name ?? "",
+    acronym: t.acronym ?? null,
+    image_url: t.image_url ?? null,
+    location: t.location ?? null,
+    players: (t.players ?? []).map((p: any) => ({
+      id: p.id,
+      name: p.name,
+      first_name: p.first_name,
+      last_name: p.last_name,
+      nationality: p.nationality,
+      role: p.role,
+      image_url: p.image_url,
+    })),
+  };
+  return NextResponse.json(data);
+}

--- a/app/api/esports/teams/route.ts
+++ b/app/api/esports/teams/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { getProxyAgent } from "../../../lib/proxyAgent";
+
+const PANDA_SCORE_TOKEN = "_PSqzloyu4BibH0XiUvNHvm9AjjnwqcrIMfwEJou6Y0i4NAXENo";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const game = searchParams.get("game") || "dota2";
+  const q = searchParams.get("q") || "";
+  const url = new URL(`https://api.pandascore.co/${game}/teams`);
+  url.searchParams.set("per_page", "5");
+  url.searchParams.set("token", PANDA_SCORE_TOKEN);
+  if (q) {
+    url.searchParams.set("search[name]", q);
+  }
+  const res = await fetch(url.toString(), {
+    cache: "no-store",
+    dispatcher: getProxyAgent(),
+  } as RequestInit & { dispatcher?: any });
+  if (!res.ok) {
+    return new NextResponse("Failed to fetch teams", { status: res.status });
+  }
+  const data = await res.json();
+  const list = (data as any[]).map((t) => ({
+    id: t.id,
+    name: t.name,
+    image_url: t.image_url ?? null,
+  }));
+  return NextResponse.json(list);
+}

--- a/app/components/TeamSearch.tsx
+++ b/app/components/TeamSearch.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+
+interface Team {
+  id: number;
+  name: string;
+  image_url: string | null;
+}
+
+export default function TeamSearch({ game = "dota2" }: { game?: string }) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Team[]>([]);
+  const [show, setShow] = useState(false);
+  const router = useRouter();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (query.length < 2) {
+      setResults([]);
+      return;
+    }
+    const controller = new AbortController();
+    fetch(`/api/esports/teams?q=${encodeURIComponent(query)}&game=${game}`, {
+      signal: controller.signal,
+    })
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setResults(data))
+      .catch(() => {});
+    return () => controller.abort();
+  }, [query, game]);
+
+  useEffect(() => {
+    function onClickOutside(e: MouseEvent) {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setShow(false);
+      }
+    }
+    document.addEventListener("click", onClickOutside);
+    return () => document.removeEventListener("click", onClickOutside);
+  }, []);
+
+  function select(team: Team) {
+    router.push(`/esports/team/${team.id}`);
+    setQuery("");
+    setShow(false);
+  }
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <input
+        type="text"
+        value={query}
+        placeholder="Buscar equipo..."
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setShow(true);
+        }}
+        onFocus={() => setShow(true)}
+        className="w-full bg-[#0f0f0f] border border-[#2a2a2a] p-2 rounded"
+      />
+      {show && results.length > 0 && (
+        <ul className="absolute z-10 left-0 right-0 bg-[#0f0f0f] border border-[#2a2a2a] mt-1 max-h-48 overflow-y-auto">
+          {results.map((t) => (
+            <li key={t.id}>
+              <button
+                onClick={() => select(t)}
+                className="flex items-center gap-2 w-full text-left p-2 hover:bg-[#1a1a1a]"
+              >
+                {t.image_url && (
+                  <img
+                    src={t.image_url}
+                    alt=""
+                    className="w-5 h-5 object-contain"
+                  />
+                )}
+                <span>{t.name}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/esports/[matchId]/page.tsx
+++ b/app/esports/[matchId]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, use } from "react";
 import Link from "next/link";
 import Countdown from "../../components/Countdown";
+import TeamSearch from "../../components/TeamSearch";
 
 interface GameInfo {
   id: number;
@@ -159,6 +160,7 @@ export default function MatchPage({
       <Link href="/esports" className="text-[var(--accent)] hover:underline">
         ← Volver
       </Link>
+      <TeamSearch />
       <h1 className="text-2xl font-bold">{match.name}</h1>
       <p className="text-sm text-gray-500">{match.league}</p>
       <p className="text-sm text-gray-400">

--- a/app/esports/page.tsx
+++ b/app/esports/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import ChatBot from "../components/ChatBot";
 import Countdown from "../components/Countdown";
+import TeamSearch from "../components/TeamSearch";
 
 interface Match {
   id: number;
@@ -170,6 +171,9 @@ export default function EsportsPage() {
       </aside>
       <div className="flex-1 pl-4 flex gap-4">
         <div className="flex-1">
+          <div className="mb-4">
+            <TeamSearch game={game} />
+          </div>
           <div className="flex justify-center gap-6 mb-4">
           {DAYS.map((d) => (
             <button

--- a/app/esports/team/[id]/page.tsx
+++ b/app/esports/team/[id]/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { use, useEffect, useState } from "react";
+import Link from "next/link";
+
+interface Player {
+  id: number;
+  name: string;
+  first_name: string | null;
+  last_name: string | null;
+  nationality: string | null;
+  role: string | null;
+  image_url: string | null;
+}
+
+interface TeamDetail {
+  id: number;
+  name: string;
+  acronym: string | null;
+  image_url: string | null;
+  location: string | null;
+  players: Player[];
+}
+
+async function fetchTeam(id: string): Promise<TeamDetail | null> {
+  const res = await fetch(`/api/esports/team/${id}`, { cache: "no-store" });
+  if (!res.ok) return null;
+  return (await res.json()) as TeamDetail;
+}
+
+export default function TeamPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const [team, setTeam] = useState<TeamDetail | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      const data = await fetchTeam(id);
+      setTeam(data);
+    }
+    load();
+  }, [id]);
+
+  if (!team) {
+    return (
+      <main className="p-4 sm:p-8 font-sans">
+        <p>Cargando...</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="p-4 sm:p-8 font-sans space-y-4">
+      <Link href="/esports" className="text-[var(--accent)] hover:underline">
+        ← Volver
+      </Link>
+      <div className="card p-4 space-y-2">
+        <h1 className="text-2xl font-bold flex items-center gap-2">
+          {team.image_url && (
+            <img src={team.image_url} alt="" className="w-8 h-8 object-contain" />
+          )}
+          {team.name}
+          {team.acronym && <span className="text-sm text-gray-400">({team.acronym})</span>}
+        </h1>
+        {team.location && <p className="text-sm text-gray-400">Ubicación: {team.location}</p>}
+      </div>
+      {team.players.length > 0 && (
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold mt-4">Jugadores</h2>
+          <ul className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+            {team.players.map((p) => (
+              <li key={p.id} className="card p-2 flex items-center gap-2">
+                {p.image_url && (
+                  <img src={p.image_url} alt="" className="w-6 h-6 object-contain" />
+                )}
+                <span className="text-sm">
+                  {p.name}
+                  {p.nationality && ` (${p.nationality})`}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/app/esports/tournament/[id]/page.tsx
+++ b/app/esports/tournament/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, use } from "react";
 import Link from "next/link";
+import TeamSearch from "../../components/TeamSearch";
 
 interface TournamentDetail {
   id: number;
@@ -94,6 +95,7 @@ export default function TournamentPage({ params }: { params: Promise<{ id: strin
       <Link href="/esports" className="text-[var(--accent)] hover:underline">
         ← Volver
       </Link>
+      <TeamSearch />
       <div className="card p-4 space-y-2">
         <h1 className="text-2xl font-bold">
           {tournament.league} {tournament.serie}


### PR DESCRIPTION
## Summary
- implement API routes to fetch team data
- create `TeamSearch` component
- create team detail page
- add team search on the main page, match page and tournament page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685c41e8928083328c2c4d30daa96423