### PR TITLE
Fix tournament page imports

### DIFF
--- a/app/esports/tournament/[id]/page.tsx
+++ b/app/esports/tournament/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, use } from "react";
 import Link from "next/link";
-import TeamSearch from "../../components/TeamSearch";
+import TeamSearch from "../../../components/TeamSearch";
 
 interface TournamentDetail {
   id: number;


### PR DESCRIPTION
## Summary
- correct TeamSearch import path in tournament details page

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_685c43f6f4bc8332ab1476f32fbcdd53