### PR TITLE
Add global search support

### DIFF
--- a/app/api/esports/player/[id]/route.ts
+++ b/app/api/esports/player/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { getProxyAgent } from "../../../../lib/proxyAgent";
+
+const PANDA_SCORE_TOKEN = "_PSqzloyu4BibH0XiUvNHvm9AjjnwqcrIMfwEJou6Y0i4NAXENo";
+
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const url = `https://api.pandascore.co/players/${id}?token=${PANDA_SCORE_TOKEN}`;
+  const res = await fetch(url, { cache: "no-store", dispatcher: getProxyAgent() } as RequestInit & { dispatcher?: any });
+  if (!res.ok) {
+    return new NextResponse("Failed to fetch player", { status: res.status });
+  }
+  const p = await res.json();
+  const data = {
+    id: p.id,
+    name: p.name ?? "",
+    first_name: p.first_name ?? null,
+    last_name: p.last_name ?? null,
+    nationality: p.nationality ?? null,
+    role: p.role ?? null,
+    image_url: p.image_url ?? null,
+    current_team: p.current_team?.name ?? null,
+  };
+  return NextResponse.json(data);
+}

--- a/app/api/esports/players/route.ts
+++ b/app/api/esports/players/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { getProxyAgent } from "../../../lib/proxyAgent";
+
+const PANDA_SCORE_TOKEN = "_PSqzloyu4BibH0XiUvNHvm9AjjnwqcrIMfwEJou6Y0i4NAXENo";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const game = searchParams.get("game") || "dota2";
+  const q = searchParams.get("q") || "";
+  const url = new URL(`https://api.pandascore.co/${game}/players`);
+  url.searchParams.set("per_page", "5");
+  url.searchParams.set("token", PANDA_SCORE_TOKEN);
+  if (q) {
+    url.searchParams.set("search[name]", q);
+  }
+  const res = await fetch(url.toString(), {
+    cache: "no-store",
+    dispatcher: getProxyAgent(),
+  } as RequestInit & { dispatcher?: any });
+  if (!res.ok) {
+    return new NextResponse("Failed to fetch players", { status: res.status });
+  }
+  const data = await res.json();
+  const list = (data as any[]).map((p) => ({
+    id: p.id,
+    name: p.name,
+    image_url: p.image_url ?? null,
+  }));
+  return NextResponse.json(list);
+}

--- a/app/api/esports/search/route.ts
+++ b/app/api/esports/search/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { getProxyAgent } from "../../../lib/proxyAgent";
+
+const PANDA_SCORE_TOKEN = "_PSqzloyu4BibH0XiUvNHvm9AjjnwqcrIMfwEJou6Y0i4NAXENo";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const game = searchParams.get("game") || "dota2";
+  const q = searchParams.get("q") || "";
+  if (q.length < 1) return NextResponse.json([]);
+  const base = `https://api.pandascore.co/${game}`;
+  const tokenParam = `token=${PANDA_SCORE_TOKEN}`;
+
+  async function load(endpoint: string) {
+    const url = `${base}/${endpoint}?per_page=5&search[name]=${encodeURIComponent(q)}&${tokenParam}`;
+    const res = await fetch(url, { cache: "no-store", dispatcher: getProxyAgent() } as RequestInit & { dispatcher?: any });
+    if (!res.ok) return [];
+    return res.json();
+  }
+
+  const [teams, players, matches] = await Promise.all([
+    load("teams"),
+    load("players"),
+    load("matches"),
+  ]);
+
+  const list = [
+    ...(teams as any[]).map((t) => ({ type: "team", id: t.id, name: t.name, image_url: t.image_url ?? null })),
+    ...(players as any[]).map((p) => ({ type: "player", id: p.id, name: p.name, image_url: p.image_url ?? null })),
+    ...(matches as any[]).map((m) => {
+      const team1 = m.opponents?.[0]?.opponent?.name ?? "TBD";
+      const team2 = m.opponents?.[1]?.opponent?.name ?? "TBD";
+      return { type: "match", id: m.id, name: `${team1} vs ${team2}`, image_url: null };
+    }),
+  ];
+
+  return NextResponse.json(list);
+}

--- a/app/components/Search.tsx
+++ b/app/components/Search.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+
+interface SearchItem {
+  id: number;
+  name: string;
+  type: "team" | "player" | "match";
+  image_url: string | null;
+}
+
+export default function Search({ game = "dota2" }: { game?: string }) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchItem[]>([]);
+  const [show, setShow] = useState(false);
+  const router = useRouter();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (query.length < 2) {
+      setResults([]);
+      return;
+    }
+    const controller = new AbortController();
+    fetch(`/api/esports/search?q=${encodeURIComponent(query)}&game=${game}`, {
+      signal: controller.signal,
+    })
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setResults(data))
+      .catch(() => {});
+    return () => controller.abort();
+  }, [query, game]);
+
+  useEffect(() => {
+    function onClickOutside(e: MouseEvent) {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setShow(false);
+      }
+    }
+    document.addEventListener("click", onClickOutside);
+    return () => document.removeEventListener("click", onClickOutside);
+  }, []);
+
+  function select(item: SearchItem) {
+    const base = item.type === "team" ? "team" : item.type === "player" ? "player" : "";
+    const path = base ? `/esports/${base}/${item.id}` : `/esports/${item.id}`;
+    router.push(path);
+    setQuery("");
+    setShow(false);
+  }
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <input
+        type="text"
+        value={query}
+        placeholder="Buscar..."
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setShow(true);
+        }}
+        onFocus={() => setShow(true)}
+        className="w-full bg-[#0f0f0f] border border-[#2a2a2a] p-2 rounded"
+      />
+      {show && results.length > 0 && (
+        <ul className="absolute z-10 left-0 right-0 bg-[#0f0f0f] border border-[#2a2a2a] mt-1 max-h-48 overflow-y-auto">
+          {results.map((r) => (
+            <li key={`${r.type}-${r.id}`}>\
+              <button
+                onClick={() => select(r)}
+                className="flex items-center gap-2 w-full text-left p-2 hover:bg-[#1a1a1a]"
+              >
+                {r.image_url && (
+                  <img src={r.image_url} alt="" className="w-5 h-5 object-contain" />
+                )}
+                <span>{r.name}</span>
+                <span className="ml-auto text-xs text-gray-400">{r.type}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/esports/[matchId]/page.tsx
+++ b/app/esports/[matchId]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, use } from "react";
 import Link from "next/link";
 import Countdown from "../../components/Countdown";
-import TeamSearch from "../../components/TeamSearch";
+import Search from "../../components/Search";
 
 interface GameInfo {
   id: number;
@@ -160,7 +160,7 @@ export default function MatchPage({
       <Link href="/esports" className="text-[var(--accent)] hover:underline">
         ← Volver
       </Link>
-      <TeamSearch />
+      <Search />
       <h1 className="text-2xl font-bold">{match.name}</h1>
       <p className="text-sm text-gray-500">{match.league}</p>
       <p className="text-sm text-gray-400">

--- a/app/esports/page.tsx
+++ b/app/esports/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import ChatBot from "../components/ChatBot";
 import Countdown from "../components/Countdown";
-import TeamSearch from "../components/TeamSearch";
+import Search from "../components/Search";
 
 interface Match {
   id: number;
@@ -172,7 +172,7 @@ export default function EsportsPage() {
       <div className="flex-1 pl-4 flex gap-4">
         <div className="flex-1">
           <div className="mb-4">
-            <TeamSearch game={game} />
+            <Search game={game} />
           </div>
           <div className="flex justify-center gap-6 mb-4">
           {DAYS.map((d) => (

--- a/app/esports/player/[id]/page.tsx
+++ b/app/esports/player/[id]/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { use, useEffect, useState } from "react";
+import Link from "next/link";
+
+interface PlayerDetail {
+  id: number;
+  name: string;
+  first_name: string | null;
+  last_name: string | null;
+  nationality: string | null;
+  role: string | null;
+  image_url: string | null;
+  current_team: string | null;
+}
+
+async function fetchPlayer(id: string): Promise<PlayerDetail | null> {
+  const res = await fetch(`/api/esports/player/${id}`, { cache: "no-store" });
+  if (!res.ok) return null;
+  return (await res.json()) as PlayerDetail;
+}
+
+export default function PlayerPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const [player, setPlayer] = useState<PlayerDetail | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      const data = await fetchPlayer(id);
+      setPlayer(data);
+    }
+    load();
+  }, [id]);
+
+  if (!player) {
+    return (
+      <main className="p-4 sm:p-8 font-sans">
+        <p>Cargando...</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="p-4 sm:p-8 font-sans space-y-4">
+      <Link href="/esports" className="text-[var(--accent)] hover:underline">
+        ← Volver
+      </Link>
+      <div className="card p-4 space-y-2">
+        <h1 className="text-2xl font-bold flex items-center gap-2">
+          {player.image_url && (
+            <img src={player.image_url} alt="" className="w-8 h-8 object-contain" />
+          )}
+          {player.name}
+        </h1>
+        {player.current_team && (
+          <p className="text-sm text-gray-400">Equipo: {player.current_team}</p>
+        )}
+        {player.role && <p className="text-sm">Rol: {player.role}</p>}
+        {player.nationality && (
+          <p className="text-sm">Nacionalidad: {player.nationality}</p>
+        )}
+        {player.first_name && player.last_name && (
+          <p className="text-sm">Nombre real: {player.first_name} {player.last_name}</p>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/app/esports/tournament/[id]/page.tsx
+++ b/app/esports/tournament/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, use } from "react";
 import Link from "next/link";
-import TeamSearch from "../../../components/TeamSearch";
+import Search from "../../../components/Search";
 
 interface TournamentDetail {
   id: number;
@@ -95,7 +95,7 @@ export default function TournamentPage({ params }: { params: Promise<{ id: strin
       <Link href="/esports" className="text-[var(--accent)] hover:underline">
         ← Volver
       </Link>
-      <TeamSearch />
+      <Search />
       <div className="card p-4 space-y-2">
         <h1 className="text-2xl font-bold">
           {tournament.league} {tournament.serie}


### PR DESCRIPTION
## Summary
- add routes to fetch players and perform combined search
- implement `Search` component for teams, players and matches
- add player detail page
- swap `TeamSearch` usages with new `Search` component

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_685d18284d5483329a6f0ec9ee3efd2f