### PR TITLE
Fix search placeholder issue

### DIFF
--- a/app/components/Search.tsx
+++ b/app/components/Search.tsx
@@ -213,7 +213,7 @@ export default function Search({
           ref={inputRef}
           type="text"
           value={query}
-          placeholder={placeholder}
+          placeholder={query ? "" : placeholder}
           onChange={(e) => {
             setQuery(e.target.value);
             setShow(true);


### PR DESCRIPTION
## Summary
- prevent placeholder from overlapping typed text in the search bar

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_687ca398423483329abb658bb1b3a329