### PR TITLE
Fix build errors with suspense boundaries

### DIFF
--- a/app/esports/page.tsx
+++ b/app/esports/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useEffect, useState, useMemo } from "react";
+export const dynamic = "force-dynamic";
+
+import { useEffect, useState, useMemo, Suspense } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import Header from "../components/Header";
@@ -435,7 +437,7 @@ function TournamentCard({ tournament, game }: { tournament: Tournament; game?: t
   );
 }
 
-export default function EsportsPage() {
+function EsportsPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   
@@ -642,7 +644,9 @@ export default function EsportsPage() {
 
   return (
     <>
-      <Header />
+      <Suspense fallback={null}>
+        <Header />
+      </Suspense>
       <LiveScoreTicker currentGame={game} />
       
       <main className="min-h-screen bg-black text-white pt-20">
@@ -1091,5 +1095,13 @@ export default function EsportsPage() {
       
       <ChatBot />
     </>
+  );
+}
+
+export default function EsportsPage() {
+  return (
+    <Suspense fallback={null}>
+      <EsportsPageContent />
+    </Suspense>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Header from "./components/Header";
+import { Suspense } from "react";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,7 +29,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[var(--background)] text-[var(--foreground)]`}
       >
-        <Header />
+        <Suspense fallback={null}>
+          <Header />
+        </Suspense>
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useEffect, useState, useMemo } from "react";
+export const dynamic = "force-dynamic";
+
+import { useEffect, useState, useMemo, Suspense } from "react";
 import Link from "next/link";
 import Header from "./components/Header";
 import ChatBot from "./components/ChatBot";
@@ -516,7 +518,9 @@ export default function Home() {
 
   return (
     <>
-      <Header />
+      <Suspense fallback={null}>
+        <Header />
+      </Suspense>
       <LiveScoreTicker currentGame="all" />
       
       <main className="min-h-screen bg-black text-white pt-20">


### PR DESCRIPTION
## Summary
- wrap `Header` in a `Suspense` boundary in the root layout
- mark pages as dynamic and wrap the header with `Suspense`
- add `EsportsPageContent` component to render inside a `Suspense` boundary

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687ca3b9cf388332bb6a63a3844fb4cb