### PR TITLE
Update Rainbow Six and Overwatch icons

### DIFF
--- a/public/overwatch.svg
+++ b/public/overwatch.svg
@@ -1,12 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="32" cy="32" r="30" fill="#F99E1A" stroke="#E8890A" stroke-width="2"/>
-  <circle cx="32" cy="32" r="24" fill="#FFFFFF"/>
-  <path d="M32 14 L46 28 L46 36 L32 50 L18 36 L18 28 Z" fill="#F99E1A"/>
-  <circle cx="32" cy="32" r="8" fill="#FFFFFF"/>
-  <path d="M28 28 L36 28 L36 36 L28 36 Z" fill="#F99E1A"/>
-  <path d="M24 24 L40 24 L40 26 L24 26 Z" fill="#E8890A"/>
-  <path d="M24 38 L40 38 L40 40 L24 40 Z" fill="#E8890A"/>
-  <path d="M24 30 L26 30 L26 34 L24 34 Z" fill="#E8890A"/>
-  <path d="M38 30 L40 30 L40 34 L38 34 Z" fill="#E8890A"/>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <title>Overwatch 2</title>
+  <path d="M12 0a12 12 0 1 0 12 12A12 12 0 0 0 12 0zm0 22.5A10.5 10.5 0 1 1 22.5 12 10.512 10.512 0 0 1 12 22.5z" fill="#F99E1A"/>
+  <path d="M4.5 12a7.5 7.5 0 0 1 15 0h2A9.5 9.5 0 0 0 4.5 12Z" fill="#fff"/>
+  <path d="M11 13.2 8.6 16.5h6.8L12.9 13.2Z" fill="#F99E1A"/>
+  <path d="M17 7h1.5a1.5 1.5 0 0 1 0 3H17z" fill="#F99E1A"/>
+  <path d="M17 11h2l2 4h-2l-2-4Z" fill="#F99E1A"/>
+  <path d="M18 15h1.5l1 2H18z" fill="#F99E1A"/>
 </svg>

--- a/public/rainbow6siege.svg
+++ b/public/rainbow6siege.svg
@@ -1,14 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="64" height="64" rx="8" fill="#FF6600"/>
-  <path d="M12 12 L52 12 L52 52 L12 52 Z" fill="#000000"/>
-  <path d="M16 16 L48 16 L48 48 L16 48 Z" fill="#FF6600"/>
-  <circle cx="32" cy="32" r="12" fill="#000000"/>
-  <circle cx="32" cy="32" r="8" fill="#FFFFFF"/>
-  <path d="M32 24 L32 40 M24 32 L40 32" stroke="#FF6600" stroke-width="2" stroke-linecap="round"/>
-  <path d="M26 26 L38 26 L38 38 L26 38 Z" fill="none" stroke="#FF6600" stroke-width="1"/>
-  <path d="M28 20 L36 20 L36 22 L28 22 Z" fill="#FFFFFF"/>
-  <path d="M28 42 L36 42 L36 44 L28 44 Z" fill="#FFFFFF"/>
-  <path d="M20 28 L22 28 L22 36 L20 36 Z" fill="#FFFFFF"/>
-  <path d="M42 28 L44 28 L44 36 L42 36 Z" fill="#FFFFFF"/>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <title>Rainbow Six Siege</title>
+  <path d="M12 .5A11.5 11.5 0 0 0 .5 12v5a6.5 6.5 0 0 0 6.5 6.5h6.5l4-4v-4.5h-4v2.75l-1.5 1.5H7a3.5 3.5 0 0 1-3.5-3.5V12A8.5 8.5 0 0 1 12 3.5h5V.5Z" fill="#FF6600"/>
+  <path d="M13 10v4h1V10h-1zm0-3v2h1V7h-1z" fill="#fff"/>
 </svg>


### PR DESCRIPTION
## Summary
- redraw Rainbow Six Siege icon
- redraw Overwatch 2 icon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688b7e470638832387f00a72bfe29c38