### PR TITLE
feat: add scroll-to-top button

### DIFF
--- a/app/components/ScrollToTop.tsx
+++ b/app/components/ScrollToTop.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function ScrollToTop() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => {
+      setIsVisible(window.scrollY > 300);
+    };
+
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <button
+      aria-label="Scroll to top"
+      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+      className={`fixed bottom-6 right-6 z-50 rounded-full bg-green-600 p-3 text-white shadow-lg transition-opacity duration-300 ${
+        isVisible ? "opacity-100" : "opacity-0 pointer-events-none"
+      }`}
+    >
+      ↑
+    </button>
+  );
+}
+

--- a/app/esports/page.tsx
+++ b/app/esports/page.tsx
@@ -11,6 +11,7 @@ import Countdown from "../components/Countdown";
 import { MatchSkeleton, TournamentSkeleton } from "../components/Skeleton";
 import LiveScoreTicker from "../components/LiveScoreTicker";
 import NotificationSystem, { useNotifications } from "../components/NotificationSystem";
+import ScrollToTop from "../components/ScrollToTop";
 
 // Icono de favorito (estrella)
 function Star({ filled, ...props }: { filled: boolean; [key: string]: any }) {
@@ -1095,6 +1096,7 @@ function EsportsPageContent() {
       />
       
       <ChatBot />
+      <ScrollToTop />
     </>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import Header from "./components/Header";
 import ChatBot from "./components/ChatBot";
 import LiveScoreTicker from "./components/LiveScoreTicker";
 import NotificationSystem, { useNotifications } from "./components/NotificationSystem";
+import ScrollToTop from "./components/ScrollToTop";
 import { MatchSkeleton } from "./components/Skeleton";
 import { SUPPORTED_GAMES, type GameConfig } from "./lib/gameConfig";
 
@@ -1031,6 +1032,7 @@ export default function Home() {
       />
       
       <ChatBot />
+      <ScrollToTop />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add scroll-to-top component for better navigation
- wire scroll-to-top into home and esports pages

## Testing
- `npm test`
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68b73638625c832d8379788e5b9466d3