### PR TITLE
Add Vercel Analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { AuthProvider } from "./contexts/AuthContext";
 import { Suspense } from "react";
 import Script from "next/script";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import { Analytics } from "@vercel/analytics/next";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -192,6 +193,7 @@ export default function RootLayout({
             `
           }} />
           <SpeedInsights />
+          <Analytics />
         </ErrorBoundary>
       </body>
     </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@firebasegen/default-connector": "file:dataconnect-generated/js/default-connector",
         "@headlessui/react": "^2.2.0",
         "@heroicons/react": "^2.1.5",
+        "@vercel/analytics": "^1.5.0",
         "@vercel/speed-insights": "^1.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -4085,6 +4086,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vercel/speed-insights": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@firebasegen/default-connector": "file:dataconnect-generated/js/default-connector",
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "^2.1.5",
+    "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- install `@vercel/analytics`
- add Vercel Analytics component to root layout

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for interactive config)*

------
https://chatgpt.com/codex/tasks/task_b_68b73da38c8c832d8a684904c03f3ff4