### PR TITLE
Prevent state mutation in match sorting

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -145,7 +145,8 @@ async function fetchAllMatches(): Promise<Match[]> {
     console.error('Error fetching matches:', error);
   }
   
-  return allMatches.sort((a, b) => a.start_time - b.start_time);
+  // Return a sorted copy to avoid mutating the aggregated results in place
+  return [...allMatches].sort((a, b) => a.start_time - b.start_time);
 }
 
 // Función para obtener torneos de múltiples juegos


### PR DESCRIPTION
## Summary
- avoid mutating aggregated match array when sorting fetched results

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c4770bb1f0832d99880c8819450d2d