### PR TITLE
fix(app): prevent infinite loop in useNotifications hook

### DIFF
--- a/app/components/NotificationSystem.tsx
+++ b/app/components/NotificationSystem.tsx
@@ -387,7 +387,7 @@ export function useNotifications() {
     return { unread, total: notifications.length, byType, byPriority };
   }, [notifications]);
 
-  return {
+  return useMemo(() => ({
     notifications,
     addNotification,
     markAsRead,
@@ -397,5 +397,5 @@ export function useNotifications() {
     markAllAsRead,
     stats,
     isLoading
-  };
+  }), [notifications, addNotification, markAsRead, deleteNotification, clearAll, deleteAll, markAllAsRead, stats, isLoading]);
 }


### PR DESCRIPTION
The useNotifications hook was returning a new object on every render, causing components that use it to re-render infinitely. This was due to the fact that the functions inside the returned object, although wrapped in useCallback, were part of a new object instance on each render.

This change wraps the returned object in a useMemo hook, ensuring that the object is only recreated when its dependencies change. This stabilizes the returned functions and prevents the infinite loop.