### PR TITLE
fix: Prevent infinite loop in useNotifications hook

### DIFF
--- a/app/components/NotificationSystem.tsx
+++ b/app/components/NotificationSystem.tsx
@@ -397,5 +397,5 @@ export function useNotifications() {
     markAllAsRead,
     stats,
     isLoading
-  }), [notifications, addNotification, markAsRead, deleteNotification, clearAll, deleteAll, markAllAsRead, stats, isLoading]);
+  }), [notifications, isLoading]);
 }


### PR DESCRIPTION
The useNotifications hook was causing an infinite re-render loop due to an incorrect dependency array in the useMemo that returns the hook's values.

The dependency array included stable callbacks and derived state, which caused the memoized object to be recreated on every render, leading to a "Minified React error #185".

This change simplifies the dependency array to only include the necessary state values, which stabilizes the returned object and breaks the infinite loop.