### PR TITLE
Fix chat state loop causing React error

### DIFF
--- a/app/components/ChatBot.tsx
+++ b/app/components/ChatBot.tsx
@@ -6,7 +6,7 @@ import { useCache } from '../lib/cache';
 import { apiCache } from '../lib/cache';
 import { debounce } from '../lib/utils';
 import { Spinner } from './LoadingOptimized';
-import { useAppActions } from '../store';
+import { useAppStore } from '../store';
 
 interface Message {
   id: string;
@@ -34,7 +34,8 @@ const MAX_MESSAGES = 50; // Limitar mensajes para rendimiento
 
 const ChatBot: React.FC = memo(() => {
   const [isOpen, setIsOpen] = useState(false);
-  const { setChatOpen } = useAppActions();
+  const setChatOpen = useAppStore(state => state.setChatOpen);
+  const chatOpenInStore = useAppStore(state => state.chatOpen);
   const [messages, setMessages] = useState<Message[]>([
     {
       id: '1',
@@ -67,9 +68,16 @@ const ChatBot: React.FC = memo(() => {
   }, [isOpen]);
 
   // Mantener estado global sincronizado para evitar solapamientos con otros botones
+  const lastSyncedOpenRef = useRef(isOpen);
+
   useEffect(() => {
+    if (lastSyncedOpenRef.current === isOpen && chatOpenInStore === isOpen) {
+      return;
+    }
+
+    lastSyncedOpenRef.current = isOpen;
     setChatOpen(isOpen);
-  }, [isOpen, setChatOpen]);
+  }, [isOpen, chatOpenInStore, setChatOpen]);
 
   // Debounced typing indicator
   const debouncedTyping = useCallback(

--- a/app/components/ScrollToTop.tsx
+++ b/app/components/ScrollToTop.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useUIState } from "../store";
+import { useAppStore } from "../store";
 
 export default function ScrollToTop() {
   const [isVisible, setIsVisible] = useState(false);
-  const { chatOpen } = useUIState();
+  const chatOpen = useAppStore(state => state.chatOpen);
 
   useEffect(() => {
     const onScroll = () => {

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { create } from 'zustand';
+import { shallow } from 'zustand/shallow';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import { subscribeWithSelector } from 'zustand/middleware';
@@ -212,6 +213,10 @@ export const useAppStore = create<AppStore>()(
           }),
 
           setSidebarOpen: (open) => set((state) => {
+            if (state.sidebarOpen === open) {
+              return;
+            }
+
             state.sidebarOpen = open;
           }),
 
@@ -220,6 +225,10 @@ export const useAppStore = create<AppStore>()(
           }),
 
           setChatOpen: (open) => set((state) => {
+            if (state.chatOpen === open) {
+              return;
+            }
+
             state.chatOpen = open;
           }),
 
@@ -228,6 +237,10 @@ export const useAppStore = create<AppStore>()(
           }),
 
           setNotificationsOpen: (open) => set((state) => {
+            if (state.notificationsOpen === open) {
+              return;
+            }
+
             state.notificationsOpen = open;
           }),
 
@@ -305,12 +318,12 @@ export const useUIState = () => useAppStore((state) => ({
   sidebarOpen: state.sidebarOpen,
   chatOpen: state.chatOpen,
   notificationsOpen: state.notificationsOpen
-}));
+}), shallow);
 export const useAppStatus = () => useAppStore((state) => ({
   isLoading: state.isLoading,
   error: state.error,
   lastUpdated: state.lastUpdated
-}));
+}), shallow);
 
 // Selectores derivados
 export const useLiveMatches = () => useAppStore((state) =>
@@ -356,7 +369,7 @@ export const useAppActions = () => useAppStore((state) => ({
   getCache: state.getCache,
   clearCache: state.clearCache,
   reset: state.reset
-}));
+}), shallow);
 
 // Middleware personalizado para logging en desarrollo
 if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
## Summary
- guard UI state setters in the store and expose selectors with shallow comparison to avoid redundant updates
- consume the chat open flag directly from the store in ScrollToTop so the snapshot stays stable
- sync the ChatBot open state with the store through guarded hooks to prevent the React maximum update depth error

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68c85cc065e0832db5190ae93d8cbc79